### PR TITLE
US6: Add React button option next to message on hover, display selected emoji at bottom of message

### DIFF
--- a/src/views/partials/chats/message.tpl
+++ b/src/views/partials/chats/message.tpl
@@ -21,6 +21,12 @@
 		<div component="chat/message/body" class="message-body ps-0 py-0 overflow-auto text-break">
 			{messages.content}
 		</div>
+		
+		<div class="message-reaction" style="display: none;">
+    		<!-- Reaction emoji will appear here -->
+		</div>
+
+
 		<!-- IMPORT partials/chats/reactions.tpl -->
 		<div component="chat/message/controls" class="position-relative">
 			<div class="btn-group border shadow-sm controls position-absolute bg-body end-0" style="bottom:1rem;">
@@ -71,8 +77,8 @@
 					</ul>
 				</div>
 
-				<button data-action="emoji" class="btn-ghost-sm px-2 d-none d-md-flex" type="button" data-bs-toggle=tooltip" aria-label="Emoji" data-bs-original-title="Emoji"><i class="fa fa-smile"></i></button>
-				
+				<button data-action="message-emoji" class="btn-ghost-sm px-2 d-none d-md-flex" type="button" data-bs-toggle=tooltip" aria-label="Emoji" data-bs-original-title="Emoji"><i class="fa fa-smile"></i></button>
+
 			</div>
 		</div>
 	</div>

--- a/src/views/partials/chats/message.tpl
+++ b/src/views/partials/chats/message.tpl
@@ -46,7 +46,7 @@
 						<li>
 							<a href="#" class="dropdown-item rounded-1" data-action="pin" role="menuitem"><span class="d-inline-flex align-items-center gap-2"><i class="fa fa-fw fa-thumbtack text-muted"></i> [[modules:chat.pin-message]]</span></a>
 						</li>
-						<li>
+						<li> 
 							<a href="#" class="dropdown-item rounded-1" data-action="unpin" role="menuitem"><span class="d-inline-flex align-items-center gap-2"><i class="fa fa-fw fa-thumbtack fa-rotate-90 text-muted"></i> [[modules:chat.unpin-message]]</span></a>
 						</li>
 						<li class="dropdown-divider"></li>
@@ -70,6 +70,9 @@
 						</li>
 					</ul>
 				</div>
+
+				<button data-action="emoji" class="btn-ghost-sm px-2 d-none d-md-flex" type="button" data-bs-toggle=tooltip" aria-label="Emoji" data-bs-original-title="Emoji"><i class="fa fa-smile"></i></button>
+				
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
**Description**:

Implements feature where React button appears next to a message (for any message) when a user hovers over it.
Implements feature that displays selected emoji under a message when a user selects an emoji from the emoji menu.

Fixes #4
Fixes #5 
Fixes #6 

**What Has Been Changed**:
- Added button element with the emoji icon with its data action defined by message-emoji to message.tpl, which appears when hovering over a message
- Also added container for reaction emojis to be displayed when user selects an emoji reaction
- Added toggle function, specific to reactions to message, which captures the emoji that is selected by a user and adds it to the according container
- Modified reaction container's CSS to display the emoji reaction within the container

**Code Changes (relevant to last 2 bullet points above, made in files within node_modules, will complete new steps that were recently given during Sprint 2):**

_In emoji-dialog.js:_

<img width="581" alt="Screenshot 2024-09-24 at 2 37 07 PM" src="https://github.com/user-attachments/assets/22d8d8a2-97b3-4e53-a1a2-5ed8f6fd6490">

_In emoji-setup.js:_

<img width="579" alt="Screenshot 2024-09-24 at 2 34 48 PM" src="https://github.com/user-attachments/assets/860d7b77-b1ff-4392-905c-deab04d6673b">


**Testing**:
- Manually tested on UI by verifying that the React button appears when I hovered over any message that was sent
- Manually tested on UI by verifying that when an emoji is selected for any message it appears at the bottom of that message
- Manually tested by including console logs that confirm that the click event for the emoji button within the message was being detected correctly
- Manually tested by including console logs to confirm that the correct emoji (the selected one) was being inserted into the reaction container