### PR TITLE
US4: Added backend logic for green endorsement checkmark

### DIFF
--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -349,6 +349,7 @@ define('forum/topic/threadTools', [
 
 		$('[component="topic/labels"] [component="topic/locked"]').toggleClass('hidden', !data.isLocked);
 		$('[component="topic/endorsed"]').toggleClass('hidden', !data.isEndorsed);
+		$('[component="topic/endorsed-checkmark"]').toggleClass('hidden', !data.isEndorsed);
 
 		ajaxify.data.endorsed = data.isEndorsed;
 		posts.addTopicEvents(data.events);


### PR DESCRIPTION
### New Features
- Added backend logic functionality that listens for clicking 'Endorse topic' button and adds green checkmark upon button click

### Testing

Manually tested through frontend testing as described in #16 